### PR TITLE
Support separate FWaaS tests for terraform-openstack-provider

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -25,6 +25,9 @@
     recheck-lbaas:
       jobs:
         - terraform-provider-openstack-acceptance-test-lbaas
+    recheck-fwaas:
+      jobs:
+        - terraform-provider-openstack-acceptance-test-fwaas
     periodic:
       jobs:
         - terraform-provider-openstack-unittest


### PR DESCRIPTION
Associate FWaaS job with terraform-openstack-provider project

Fixes: https://github.com/theopenlab/openlab-zuul-jobs/issues/35

Part of https://github.com/orgs/theopenlab/projects/1#card-6800912